### PR TITLE
Fix the "Ignore Matrix Tracks" export option that prevents these tracks from being exported independently

### DIFF
--- a/BinaryData/Resource/ChangeLog.txt
+++ b/BinaryData/Resource/ChangeLog.txt
@@ -1,4 +1,5 @@
 
+- Fix: The "Ignore Matrix Tracks" export option prevents these tracks from being exported independently
 - Add: Add a logarithmic scale parameter to tracks that have frequency values in hertz enhancement
 
 v2.0.4

--- a/Source/Document/AnlDocumentExporter.cpp
+++ b/Source/Document/AnlDocumentExporter.cpp
@@ -813,10 +813,10 @@ juce::Result Document::Exporter::toFile(Accessor& accessor, juce::File const fil
     else if(options.useTextFormat() && options.ignoreGridResults)
     {
         auto const& tracks = getAllTrackAcsrs();
-        if(std::all_of(tracks.cbegin(), tracks.cend(), [](auto const& trackAcsr)
-                       {
-                           return Track::Tools::getFrameType(trackAcsr.get()) == Track::FrameType::vector;
-                       }))
+        if(tracks.size() > 1_z && std::all_of(tracks.cbegin(), tracks.cend(), [](auto const& trackAcsr)
+                                              {
+                                                  return Track::Tools::getFrameType(trackAcsr.get()) == Track::FrameType::vector;
+                                              }))
         {
             return juce::Result::fail("Invalid format for items");
         }


### PR DESCRIPTION
closes #15 