### PR TITLE
Fix selection of an empty track (when plugin initialisation failed)

### DIFF
--- a/Source/Document/AnlDocumentSelection.cpp
+++ b/Source/Document/AnlDocumentSelection.cpp
@@ -122,7 +122,7 @@ std::set<juce::String> Document::Selection::getTracks(Accessor const& accessor)
     auto const trackAcsrs = accessor.getAcsrs<AcsrType::tracks>();
     for(auto const& trackAcsr : trackAcsrs)
     {
-        if(Track::Tools::isSelected(trackAcsr.get()))
+        if(Track::Tools::isSelected(trackAcsr.get(), true))
         {
             tracks.insert(trackAcsr.get().getAttr<Track::AttrType::identifier>());
         }

--- a/Source/Track/AnlTrackSection.cpp
+++ b/Source/Track/AnlTrackSection.cpp
@@ -55,7 +55,7 @@ Track::Section::Section(Director& director, juce::ApplicationCommandManager& com
             }
             case AttrType::focused:
             {
-                mThumbnailDecoration.setHighlighted(Tools::isSelected(acsr));
+                mThumbnailDecoration.setHighlighted(Tools::isSelected(acsr, true));
                 mEditor.setFocusInfo(acsr.getAttr<AttrType::focused>());
                 break;
             }

--- a/Source/Track/AnlTrackThumbnail.cpp
+++ b/Source/Track/AnlTrackThumbnail.cpp
@@ -170,7 +170,7 @@ void Track::Thumbnail::paint(juce::Graphics& g)
     auto constexpr separator = 2;
     auto constexpr rotation = -1.5707963268f;
 
-    auto const focused = Tools::isSelected(mAccessor);
+    auto const focused = Tools::isSelected(mAccessor, true);
     g.setColour(findColour(ColourIds::backgroundColourId).contrasting(focused ? 0.1f : 0.0f));
     g.fillRoundedRectangle(getLocalBounds().toFloat(), 2.0f);
 

--- a/Source/Track/AnlTrackTools.cpp
+++ b/Source/Track/AnlTrackTools.cpp
@@ -255,8 +255,12 @@ std::optional<Zoom::Range> Track::Tools::getExtraRange(Accessor const& accessor,
     return static_cast<bool>(access) ? results.getExtraRange(index) : std::optional<Zoom::Range>();
 }
 
-bool Track::Tools::isSelected(Accessor const& acsr)
+bool Track::Tools::isSelected(Accessor const& acsr, bool emptyTrackSupport)
 {
+    if(emptyTrackSupport && acsr.getAttr<AttrType::channelsLayout>().empty())
+    {
+        return acsr.getAttr<AttrType::focused>().size() >= 1_z && acsr.getAttr<AttrType::focused>()[0];
+    }
     return !getSelectedChannels(acsr).empty();
 }
 

--- a/Source/Track/AnlTrackTools.h
+++ b/Source/Track/AnlTrackTools.h
@@ -39,7 +39,7 @@ namespace Track
         std::optional<Zoom::Range> getBinRange(Plugin::Description const& description);
         std::optional<Zoom::Range> getExtraRange(Accessor const& accessor, size_t index);
 
-        bool isSelected(Accessor const& acsr);
+        bool isSelected(Accessor const& acsr, bool emptyTrackSupport);
         std::set<size_t> getSelectedChannels(Accessor const& acsr);
         std::optional<size_t> getChannel(Accessor const& acsr, juce::Rectangle<int> const& bounds, int y, bool ignoreSeparator);
         std::optional<std::tuple<size_t, juce::Range<int>>> getChannelVerticalRange(Accessor const& acsr, juce::Rectangle<int> const& bounds, int y, bool ignoreSeparator);


### PR DESCRIPTION
closes #90 