### PR TITLE
Adding a menu to select a translation in Partiels.

### DIFF
--- a/Source/Application/AnlApplicationAudioReader.cpp
+++ b/Source/Application/AnlApplicationAudioReader.cpp
@@ -14,6 +14,7 @@ Application::AudioReader::AudioReader()
             case AttrType::recentlyOpenedFilesList:
             case AttrType::currentDocumentFile:
             case AttrType::defaultTemplateFile:
+            case AttrType::currentTranslationFile:
             case AttrType::colourMode:
             case AttrType::showInfoBubble:
             case AttrType::exportOptions:

--- a/Source/Application/AnlApplicationAudioSettings.cpp
+++ b/Source/Application/AnlApplicationAudioSettings.cpp
@@ -158,6 +158,7 @@ Application::AudioSettingsContent::AudioSettingsContent()
             case AttrType::recentlyOpenedFilesList:
             case AttrType::currentDocumentFile:
             case AttrType::defaultTemplateFile:
+            case AttrType::currentTranslationFile:
             case AttrType::colourMode:
             case AttrType::showInfoBubble:
             case AttrType::exportOptions:

--- a/Source/Application/AnlApplicationBatcher.cpp
+++ b/Source/Application/AnlApplicationBatcher.cpp
@@ -50,6 +50,7 @@ Application::BatcherContent::BatcherContent()
             case AttrType::recentlyOpenedFilesList:
             case AttrType::currentDocumentFile:
             case AttrType::defaultTemplateFile:
+            case AttrType::currentTranslationFile:
             case AttrType::colourMode:
             case AttrType::showInfoBubble:
             case AttrType::autoLoadConvertedFile:

--- a/Source/Application/AnlApplicationCommandTarget.cpp
+++ b/Source/Application/AnlApplicationCommandTarget.cpp
@@ -16,6 +16,7 @@ Application::CommandTarget::CommandTarget()
         {
             case AttrType::recentlyOpenedFilesList:
             case AttrType::defaultTemplateFile:
+            case AttrType::currentTranslationFile:
             case AttrType::silentFileManagement:
             {
                 Instance::get().getApplicationCommandManager().commandStatusChanged();

--- a/Source/Application/AnlApplicationConverter.cpp
+++ b/Source/Application/AnlApplicationConverter.cpp
@@ -154,6 +154,7 @@ Application::ConverterContent::ConverterContent()
             case AttrType::recentlyOpenedFilesList:
             case AttrType::currentDocumentFile:
             case AttrType::defaultTemplateFile:
+            case AttrType::currentTranslationFile:
             case AttrType::colourMode:
             case AttrType::showInfoBubble:
             case AttrType::exportOptions:

--- a/Source/Application/AnlApplicationExporter.cpp
+++ b/Source/Application/AnlApplicationExporter.cpp
@@ -42,6 +42,7 @@ Application::ExporterContent::ExporterContent()
             case AttrType::recentlyOpenedFilesList:
             case AttrType::currentDocumentFile:
             case AttrType::defaultTemplateFile:
+            case AttrType::currentTranslationFile:
             case AttrType::colourMode:
             case AttrType::showInfoBubble:
             case AttrType::adaptationToSampleRate:

--- a/Source/Application/AnlApplicationInstance.cpp
+++ b/Source/Application/AnlApplicationInstance.cpp
@@ -123,6 +123,16 @@ void Application::Instance::initialise(juce::String const& commandLine)
             case AttrType::lastVersion:
             case AttrType::timeZoomAnchorOnPlayhead:
                 break;
+            case AttrType::currentTranslationFile:
+            {
+                auto const file = acsr.getAttr<AttrType::currentTranslationFile>();
+                juce::LocalisedStrings::setCurrentMappings(std::make_unique<juce::LocalisedStrings>(file.existsAsFile() ? file : MainMenuModel::getSystemDefaultTranslationFile(), false).release());
+                mMainMenuModel->menuItemsChanged();
+#ifdef JUCE_MAC
+                mMainMenuModel->updateAppleMenuItems();
+#endif
+                break;
+            }
             case AttrType::autoUpdate:
             case AttrType::recentlyOpenedFilesList:
             case AttrType::defaultTemplateFile:

--- a/Source/Application/AnlApplicationLoader.cpp
+++ b/Source/Application/AnlApplicationLoader.cpp
@@ -21,6 +21,7 @@ Application::LoaderContent::FileTable::FileTable()
             case AttrType::windowState:
             case AttrType::currentDocumentFile:
             case AttrType::defaultTemplateFile:
+            case AttrType::currentTranslationFile:
             case AttrType::colourMode:
             case AttrType::showInfoBubble:
             case AttrType::exportOptions:
@@ -262,6 +263,7 @@ Application::LoaderContent::LoaderContent()
             case AttrType::windowState:
             case AttrType::recentlyOpenedFilesList:
             case AttrType::currentDocumentFile:
+            case AttrType::currentTranslationFile:
             case AttrType::colourMode:
             case AttrType::showInfoBubble:
             case AttrType::exportOptions:

--- a/Source/Application/AnlApplicationMainMenuModel.cpp
+++ b/Source/Application/AnlApplicationMainMenuModel.cpp
@@ -236,4 +236,9 @@ juce::File Application::MainMenuModel::getEmbeddedTranslationsDirectory()
 #endif
 }
 
+juce::File Application::MainMenuModel::getUserTranslationsDirectory()
+{
+    return Properties::getFile("").getSiblingFile("Partiels").getChildFile("Translations");
+}
+
 ANALYSE_FILE_END

--- a/Source/Application/AnlApplicationMainMenuModel.cpp
+++ b/Source/Application/AnlApplicationMainMenuModel.cpp
@@ -263,6 +263,8 @@ void Application::MainMenuModel::updateAppleMenuItems()
     extraAppleMenuItems.addCommandItem(&commandManager, CommandIDs::helpOpenPluginSettings);
     extraAppleMenuItems.addCommandItem(&commandManager, CommandIDs::helpOpenKeyMappings);
     addGlobalSettingsMenu(extraAppleMenuItems);
+    // This is a hack to update the main menu when the translation changes
+    juce::MenuBarModel::setMacMainMenu(nullptr, nullptr);
     juce::MenuBarModel::setMacMainMenu(this, &extraAppleMenuItems);
 }
 #endif

--- a/Source/Application/AnlApplicationMainMenuModel.cpp
+++ b/Source/Application/AnlApplicationMainMenuModel.cpp
@@ -29,7 +29,7 @@ Application::MainMenuModel::~MainMenuModel()
 
 juce::StringArray Application::MainMenuModel::getMenuBarNames()
 {
-    return {"File", "Edit", "Frame", "Transport", "View", "Help"};
+    return {juce::translate("File"), juce::translate("Edit"), juce::translate("Frame"), juce::translate("Transport"), juce::translate("View"), juce::translate("Help")};
 }
 
 juce::PopupMenu Application::MainMenuModel::getMenuForIndex(int topLevelMenuIndex, juce::String const& menuName)
@@ -39,7 +39,7 @@ juce::PopupMenu Application::MainMenuModel::getMenuForIndex(int topLevelMenuInde
     using CommandIDs = CommandTarget::CommandIDs;
     auto& commandManager = Instance::get().getApplicationCommandManager();
     juce::PopupMenu menu;
-    if(menuName == "File")
+    if(menuName == juce::translate("File"))
     {
         menu.addCommandItem(&commandManager, CommandIDs::documentNew);
         menu.addCommandItem(&commandManager, CommandIDs::documentOpen);
@@ -61,7 +61,7 @@ juce::PopupMenu Application::MainMenuModel::getMenuForIndex(int topLevelMenuInde
                                     });
         }
 
-        menu.addSubMenu("Open Recent", recentFilesMenu);
+        menu.addSubMenu(juce::translate("Open Recent"), recentFilesMenu);
         menu.addCommandItem(&commandManager, CommandIDs::documentSave);
         menu.addCommandItem(&commandManager, CommandIDs::documentDuplicate);
         menu.addCommandItem(&commandManager, CommandIDs::documentConsolidate);
@@ -71,7 +71,7 @@ juce::PopupMenu Application::MainMenuModel::getMenuForIndex(int topLevelMenuInde
         menu.addCommandItem(&commandManager, CommandIDs::documentBatch);
         menu.addSeparator();
     }
-    else if(menuName == "Edit")
+    else if(menuName == juce::translate("Edit"))
     {
         menu.addCommandItem(&commandManager, CommandIDs::editUndo);
         menu.addCommandItem(&commandManager, CommandIDs::editRedo);
@@ -80,7 +80,7 @@ juce::PopupMenu Application::MainMenuModel::getMenuForIndex(int topLevelMenuInde
         menu.addCommandItem(&commandManager, CommandIDs::editNewTrack);
         menu.addCommandItem(&commandManager, CommandIDs::editNewGroup);
     }
-    else if(menuName == "Frame")
+    else if(menuName == juce::translate("Frame"))
     {
         menu.addCommandItem(&commandManager, CommandIDs::frameSelectAll);
         menu.addCommandItem(&commandManager, CommandIDs::frameDelete);
@@ -95,7 +95,7 @@ juce::PopupMenu Application::MainMenuModel::getMenuForIndex(int topLevelMenuInde
         menu.addSeparator();
         menu.addCommandItem(&commandManager, CommandIDs::frameToggleDrawing);
     }
-    else if(menuName == "Transport")
+    else if(menuName == juce::translate("Transport"))
     {
         menu.addCommandItem(&commandManager, CommandIDs::transportTogglePlayback);
         menu.addCommandItem(&commandManager, CommandIDs::transportToggleLooping);
@@ -106,7 +106,7 @@ juce::PopupMenu Application::MainMenuModel::getMenuForIndex(int topLevelMenuInde
         menu.addCommandItem(&commandManager, CommandIDs::transportMovePlayHeadBackward);
         menu.addCommandItem(&commandManager, CommandIDs::transportMovePlayHeadForward);
     }
-    else if(menuName == "View")
+    else if(menuName == juce::translate("View"))
     {
         juce::PopupMenu colourModeMenu;
         auto const selectedMode = Instance::get().getApplicationAccessor().getAttr<AttrType::colourMode>();
@@ -143,7 +143,7 @@ juce::PopupMenu Application::MainMenuModel::getMenuForIndex(int topLevelMenuInde
         menu.addSeparator();
         menu.addCommandItem(&commandManager, CommandIDs::viewShowItemProperties);
     }
-    else if(menuName == "Help")
+    else if(menuName == juce::translate("Help"))
     {
 #ifndef JUCE_MAC
         menu.addCommandItem(&commandManager, CommandIDs::helpOpenAbout);

--- a/Source/Application/AnlApplicationMainMenuModel.cpp
+++ b/Source/Application/AnlApplicationMainMenuModel.cpp
@@ -241,4 +241,19 @@ juce::File Application::MainMenuModel::getUserTranslationsDirectory()
     return Properties::getFile("").getSiblingFile("Partiels").getChildFile("Translations");
 }
 
+juce::File Application::MainMenuModel::getSystemDefaultTranslationFile()
+{
+    auto const userLanguage = juce::SystemStats::getUserLanguage();
+    auto translations = getEmbeddedTranslationsDirectory().findChildFiles(juce::File::TypesOfFileToFind::findFiles, false, "*.txt", juce::File::FollowSymlinks::no);
+    getUserTranslationsDirectory().findChildFiles(translations, juce::File::TypesOfFileToFind::findFiles, false, "*.txt", juce::File::FollowSymlinks::no);
+    for(auto const& file : translations)
+    {
+        if(juce::LocalisedStrings(file, false).getCountryCodes().contains(userLanguage))
+        {
+            return file;
+        }
+    }
+    return juce::File();
+}
+
 ANALYSE_FILE_END

--- a/Source/Application/AnlApplicationMainMenuModel.cpp
+++ b/Source/Application/AnlApplicationMainMenuModel.cpp
@@ -226,4 +226,14 @@ void Application::MainMenuModel::updateAppleMenuItems()
 }
 #endif
 
+juce::File Application::MainMenuModel::getEmbeddedTranslationsDirectory()
+{
+    auto const exeFile = juce::File::getSpecialLocation(juce::File::SpecialLocationType::currentExecutableFile);
+#if JUCE_MAC
+    return exeFile.getParentDirectory().getSiblingFile("Resources").getChildFile("Translations");
+#else
+    return exeFile.getSiblingFile("Translations");
+#endif
+}
+
 ANALYSE_FILE_END

--- a/Source/Application/AnlApplicationMainMenuModel.h
+++ b/Source/Application/AnlApplicationMainMenuModel.h
@@ -23,6 +23,7 @@ namespace Application
 #endif
 
         static juce::File getEmbeddedTranslationsDirectory();
+        static juce::File getUserTranslationsDirectory();
 
     private:
         void addGlobalSettingsMenu(juce::PopupMenu& menu);

--- a/Source/Application/AnlApplicationMainMenuModel.h
+++ b/Source/Application/AnlApplicationMainMenuModel.h
@@ -24,6 +24,7 @@ namespace Application
 
         static juce::File getEmbeddedTranslationsDirectory();
         static juce::File getUserTranslationsDirectory();
+        static juce::File getSystemDefaultTranslationFile();
 
     private:
         void addGlobalSettingsMenu(juce::PopupMenu& menu);

--- a/Source/Application/AnlApplicationMainMenuModel.h
+++ b/Source/Application/AnlApplicationMainMenuModel.h
@@ -28,6 +28,7 @@ namespace Application
 
     private:
         void addGlobalSettingsMenu(juce::PopupMenu& menu);
+        void addTranslationsMenu(juce::PopupMenu& menu);
 #ifndef JUCE_MAC
         juce::DocumentWindow& mWindow;
 #endif

--- a/Source/Application/AnlApplicationMainMenuModel.h
+++ b/Source/Application/AnlApplicationMainMenuModel.h
@@ -22,6 +22,8 @@ namespace Application
         void updateAppleMenuItems();
 #endif
 
+        static juce::File getEmbeddedTranslationsDirectory();
+
     private:
         void addGlobalSettingsMenu(juce::PopupMenu& menu);
 #ifndef JUCE_MAC

--- a/Source/Application/AnlApplicationModel.h
+++ b/Source/Application/AnlApplicationModel.h
@@ -24,6 +24,7 @@ namespace Application
         , recentlyOpenedFilesList
         , currentDocumentFile
         , defaultTemplateFile
+        , currentTranslationFile
         , colourMode
         , showInfoBubble
         , exportOptions
@@ -47,6 +48,7 @@ namespace Application
     , Model::Attr<AttrType::recentlyOpenedFilesList, std::vector<juce::File>, Model::Flag::basic>
     , Model::Attr<AttrType::currentDocumentFile, juce::File, Model::Flag::basic>
     , Model::Attr<AttrType::defaultTemplateFile, juce::File, Model::Flag::basic>
+    , Model::Attr<AttrType::currentTranslationFile, juce::File, Model::Flag::basic>
     , Model::Attr<AttrType::colourMode, ColourMode, Model::Flag::basic>
     , Model::Attr<AttrType::showInfoBubble, bool, Model::Flag::basic>
     , Model::Attr<AttrType::exportOptions, Document::Exporter::Options, Model::Flag::basic>
@@ -78,6 +80,7 @@ namespace Application
             , {std::vector<juce::File>{}}
             , {juce::File{}}
             , {getFactoryTemplateFile()}
+            , {juce::File{}}
             , {ColourMode::automatic}
             , {true}
             , {}

--- a/Source/Application/AnlApplicationProperties.h
+++ b/Source/Application/AnlApplicationProperties.h
@@ -18,6 +18,7 @@ namespace Application
         ~Properties() override;
 
         static void askToRestoreDefaultAudioSettings(juce::String const& error);
+        static juce::File getFile(juce::StringRef const& fileName);
 
     private:
         // juce::ChangeListener
@@ -32,7 +33,6 @@ namespace Application
         };
         // clang-format on
 
-        static juce::File getFile(juce::StringRef const& fileName);
         void saveToFile(PropertyType type);
         void loadFromFile(PropertyType type);
 


### PR DESCRIPTION
This adds a menu in Partiels from which the user can select a translation.
At the start of the application, Partiels will look into a first directory for the embedded translation, then in a second directory for the translations the user might have added.
This also adds a "default" translation option, which gets your system's language and tries to find a translation for it. If no translation is found, it falls back on English.
This PR also contains small fixes by translating some entries that were not translated before.