### PR TITLE
Use the cmd/trl modifier key to force the loop to the global range, even if there are markers, when double-clicking the loop bar

### DIFF
--- a/Dependencies/Misc/Source/Transport/MiscTransportBars.cpp
+++ b/Dependencies/Misc/Source/Transport/MiscTransportBars.cpp
@@ -285,9 +285,18 @@ Transport::LoopBar::LoopBar(Accessor& accessor, Zoom::Accessor& zoomAcsr)
 
     mSelectionBar.onDoubleClick = [this](double value)
     {
-        auto const& markers = mAccessor.getAttr<AttrType::markers>();
-        auto const range = Zoom::Tools::getNearestRange(mZoomAccessor, value, markers);
-        mSelectionBar.setRange(range, Anchor::start, juce::NotificationType::sendNotificationSync);
+        if(juce::ModifierKeys::currentModifiers.isCommandDown())
+        {
+            auto const range = mZoomAccessor.getAttr<Zoom::AttrType::globalRange>();
+            mSelectionBar.setRange(range, Anchor::start, juce::NotificationType::sendNotificationSync);
+        }
+        else
+        {
+            auto const& markers = mAccessor.getAttr<AttrType::markers>();
+            auto const range = Zoom::Tools::getNearestRange(mZoomAccessor, value, markers);
+            mSelectionBar.setRange(range, Anchor::start, juce::NotificationType::sendNotificationSync);
+        }
+        auto const range = std::get<0_z>(mSelectionBar.getRange());
         mAccessor.setAttr<AttrType::startPlayhead>(range.getStart(), NotificationType::synchronous);
     };
 

--- a/Dependencies/Misc/Source/Transport/MiscTransportBars.cpp
+++ b/Dependencies/Misc/Source/Transport/MiscTransportBars.cpp
@@ -45,9 +45,8 @@ Transport::PlayheadBar::PlayheadBar(Accessor& accessor, Zoom::Accessor& zoomAcsr
         }
     };
 
-    mZoomListener.onAttrChanged = [&](Zoom::Accessor const& acsr, Zoom::AttrType const attribute)
+    mZoomListener.onAttrChanged = [&]([[maybe_unused]] Zoom::Accessor const& acsr, Zoom::AttrType const attribute)
     {
-        juce::ignoreUnused(acsr);
         switch(attribute)
         {
             case Zoom::AttrType::globalRange:
@@ -167,9 +166,8 @@ Transport::SelectionBar::SelectionBar(Accessor& accessor, Zoom::Accessor& zoomAc
         mAccessor.setAttr<AttrType::selection>(juce::Range<double>::emptyRange(value), NotificationType::synchronous);
     };
 
-    mSelectionBar.onMouseUp = [this](double value)
+    mSelectionBar.onMouseUp = [this]([[maybe_unused]] double value)
     {
-        juce::ignoreUnused(value);
         auto const range = std::get<0_z>(mSelectionBar.getRange());
         mAccessor.setAttr<AttrType::startPlayhead>(range.getStart(), NotificationType::synchronous);
     };
@@ -279,9 +277,8 @@ Transport::LoopBar::LoopBar(Accessor& accessor, Zoom::Accessor& zoomAcsr)
         mAccessor.setAttr<AttrType::startPlayhead>(value, NotificationType::synchronous);
     };
 
-    mSelectionBar.onMouseUp = [this](double value)
+    mSelectionBar.onMouseUp = [this]([[maybe_unused]] double value)
     {
-        juce::ignoreUnused(value);
         auto const range = std::get<0_z>(mSelectionBar.getRange());
         mAccessor.setAttr<AttrType::startPlayhead>(range.getStart(), NotificationType::synchronous);
     };

--- a/Dependencies/Misc/Source/Zoom/MiscZoomSelectionBar.cpp
+++ b/Dependencies/Misc/Source/Zoom/MiscZoomSelectionBar.cpp
@@ -6,9 +6,8 @@ MISC_FILE_BEGIN
 Zoom::SelectionBar::SelectionBar(Accessor& accessor)
 : mAccessor(accessor)
 {
-    mListener.onAttrChanged = [&](Accessor const& acsr, AttrType const attribute)
+    mListener.onAttrChanged = [&]([[maybe_unused]] Accessor const& acsr, AttrType const attribute)
     {
-        juce::ignoreUnused(acsr);
         switch(attribute)
         {
             case AttrType::minimumLength:

--- a/Docs/Partiels-Manual.md
+++ b/Docs/Partiels-Manual.md
@@ -497,7 +497,8 @@ The actions to move the start position of the playback head and control the play
   - Click on the borders of the existing loop range without any keyboard modifier and dragging to resize the starting or the ending of the loop range.
   - Click and drag anywhere else without any keyboard modifier to select a new loop range.
   - Click and drag with `⇧ Shift` on the loop range to shift the loop range over the time.
-  - Double click on the loop bar to select the range between the two closest markers.
+  - Double click on the loop bar to select the range between the two closest markers (or the global range when there is no marker).
+  - Double click with `⌘` (Mac) or `Ctrl` (Linux/Windows) on the loop bar to select the global range.
 - Stop the playback automatically at the end of the loop: Use the main menu `Transport → Toggle Stop Playback at Loop End` to enable or disable the option.
 - Rewind playhead: Click the rewind button (**T3**), use the main menu `Transport → Rewind Playhead` or the keyboard shortcut `⌘ Cmd + W` (Mac) or `Ctrl + W` (Linux/Windows) to move the playhead to the beginning of the audio files or the beginning of the play loop if the loop is enabled.  
 - Move playhead backward: Use the main menu `Transport → Move the Playhead Backward` or the keyboard shortcut `⌘ Cmd + ←` (Mac) or `Ctrl + ←` (Linux/Windows) to move the playhead to the previous marker when the magnetize option is enabled.  


### PR DESCRIPTION
This PR updates the behavior of the loop bar according to issue #125, updates the manual, and fixes uses of `juce::ignoreUnused()`.

closes #125 