### PR TITLE
Improved error message when analyzing and exporting document results

### DIFF
--- a/BinaryData/Translations/French.txt
+++ b/BinaryData/Translations/French.txt
@@ -112,7 +112,7 @@ countries: fr be
 "Cannot copy from SRCFLNAME to DSTFLNAME" = "Impossible de copier de SRCFLNAME à DSTFLNAME"
 "Font Style" = "Style de police"
 "Metadata MDNM of the audio file" = "Métadonnées MDNM du fichier audio"
-"Warning generated!" = "Avertissement généré !"
+"Error: The track TRACKNAME contains an ERRORTYPE error!" = "Erreur : La piste TRACKNAME contient une erreur de type ERRORTYPE !"
 "Do you still want to quit the app? Note that a running analysis may block the application from closing until it completes." = "Voulez-vous toujours quitter l'application ? Notez qu'une analyse en cours peut empêcher l'application de se fermer jusqu'à ce qu'elle soit terminée."
 "Move the Playhead Forward" = "Déplacer la tête de lecture vers l'avant"
 "The plugin [KEYID - KEYFEATURE] of the track TKNAME cannot be loaded: REASON." = "Le plugin [KEYID - KEYFEATURE] de la piste TKNAME ne peut pas être chargé : RAISON."

--- a/Source/Document/AnlDocumentExecutor.cpp
+++ b/Source/Document/AnlDocumentExecutor.cpp
@@ -62,12 +62,15 @@ juce::Result Document::Executor::launch()
 {
     anlDebug("Executor", "Check for warnings...");
     auto const trackAcsrs = mAccessor.getAcsrs<Document::AcsrType::tracks>();
-    if(std::any_of(trackAcsrs.cbegin(), trackAcsrs.cend(), [&](auto const& trackAcsr)
-                   {
-                       return trackAcsr.get().template getAttr<Track::AttrType::warnings>() != Track::WarningType::none;
-                   }))
+    auto const warningTrackIt = std::find_if(trackAcsrs.cbegin(), trackAcsrs.cend(), [&](auto const& trackAcsr)
+                                             {
+                                                 return trackAcsr.get().template getAttr<Track::AttrType::warnings>() != Track::WarningType::none;
+                                             });
+    if(warningTrackIt != trackAcsrs.cend())
     {
-        return juce::Result::fail(juce::translate("Warning generated!"));
+        auto const trackName = warningTrackIt->get().getAttr<Track::AttrType::name>();
+        auto const warningType = std::string(magic_enum::enum_name(warningTrackIt->get().getAttr<Track::AttrType::warnings>()));
+        return juce::Result::fail(juce::translate("Error: The track TRACKNAME contains an ERRORTYPE error!").replace("TRACKNAME", trackName).replace("ERRORTYPE", warningType));
     }
 
     timerCallback();


### PR DESCRIPTION
In the command line, if a problem occurs when exporting the results of a document (following the use of a plugin, loading a file, etc.), only the message ‘Warning generated!’ is displayed. This PR improves the information message by displaying the name of the track causing the problem and the type of problem.