### PR TITLE
Corrected the path replacement mechanism when loading templates or sharing documents to fix missing files

### DIFF
--- a/BinaryData/Tests/Template.ptldoc
+++ b/BinaryData/Tests/Template.ptldoc
@@ -3,10 +3,10 @@
 <document MiscModelVersion="131081" viewport_x="0" viewport_y="0" path="/Users/guillot/Git/Partiels/BinaryData/Tests/Template.ptldoc"
           grid="1" autoresize="1" samplerate="44100.0" channels="2">
   <reader>
-    <value file="/Users/guillot/Nextcloud/Sounds/Sound1.wav" channel="0"/>
+    <value file="/Users/guillot/Git/Partiels/BinaryData/Tests/Sound.wav" channel="0"/>
   </reader>
   <reader>
-    <value file="/Users/guillot/Nextcloud/Sounds/Sound1.wav" channel="1"/>
+    <value file="/Users/guillot/Git/Partiels/BinaryData/Tests/Sound.wav" channel="1"/>
   </reader>
   <layout value="dc5e59b9f3654979946bb384fcf0e673"/>
   <layout value="d6e44a1123f84fa3bd19c28f558c2d5b"/>

--- a/BinaryData/Tests/TemplateWithFileNoColour.ptldoc
+++ b/BinaryData/Tests/TemplateWithFileNoColour.ptldoc
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<document MiscModelVersion="131084" viewport_x="0" viewport_y="0" path="/Users/guillot/Git/Partiels/BinaryData/Tests/TemplateWithFileNoColour.ptldoc"
+          grid="1" autoresize="1" samplerate="44100.0" channels="2">
+  <reader>
+    <value file="/Users/guillot/Git/Partiels/BinaryData/Tests/Sound.wav"
+           channel="0"/>
+  </reader>
+  <reader>
+    <value file="/Users/guillot/Git/Partiels/BinaryData/Tests/Sound.wav"
+           channel="1"/>
+  </reader>
+  <layout value="dc5e59b9f3654979946bb384fcf0e673"/>
+  <timeZoom MiscModelVersion="131084" globalRange_start="0.0" globalRange_end="4.338231292517007"
+            minimumLength="0.01160997732426304" visibleRange_start="0.0"
+            visibleRange_end="4.338231292517007">
+    <grid MiscModelVersion="131084" tickReference="0.0" mainTickInterval="0"
+          tickPowerBase="2.0" tickDivisionFactor="10.0"/>
+  </timeZoom>
+  <transport MiscModelVersion="131084" startPlayhead="0.7593460798953728"
+             looping="0" loopRange_start="0.0" loopRange_end="0.0" stopAtLoopEnd="0"
+             autoScroll="1" gain="3.981071705534973" magnetize="0"/>
+  <groups MiscModelVersion="131084" identifier="dc5e59b9f3654979946bb384fcf0e673"
+          name="Group 1" height="748" colour="0" expanded="0" referenceid="">
+    <layout value="e9d315cd57c74c45a617e33f7db701f1"/>
+    <zoom MiscModelVersion="131084" globalRange_start="0.0" globalRange_end="1.0"
+          minimumLength="0.0" visibleRange_start="0.0" visibleRange_end="1.0">
+      <grid MiscModelVersion="131084" tickReference="0.0" mainTickInterval="3"
+            tickPowerBase="2.0" tickDivisionFactor="5.0"/>
+    </zoom>
+  </groups>
+  <tracks MiscModelVersion="131084" identifier="e9d315cd57c74c45a617e33f7db701f1"
+          name="Markers" input="" sampleRate="44100.0" height="78" font="Nunito Sans; 14.0 Regular"
+          lineWidth="2.0" showInGroup="1" sendViaOsc="0" zoomValueMode="0"
+          zoomLogScale="0" zoomLink="1">
+    <file path="/Users/guillot/Git/Partiels/BinaryData/Tests/Markers.csv"
+          commit="">
+      <args>
+        <pair key="separator" value=","/>
+        <pair key="useendtime" value="true"/>
+      </args>
+    </file>
+  </tracks>
+</document>

--- a/BinaryData/Tests/TemplateWithFileUnix.ptldoc
+++ b/BinaryData/Tests/TemplateWithFileUnix.ptldoc
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<document MiscModelVersion="131084" viewport_x="0" viewport_y="0" path="/Users/guillot/Git/Partiels/BinaryData/Tests/TemplateWithFileUnix.ptldoc"
+          grid="1" autoresize="1" samplerate="44100.0" channels="2">
+  <reader>
+    <value file="/Users/guillot/Git/Partiels/BinaryData/Tests/Sound.wav" channel="0"/>
+  </reader>
+  <reader>
+    <value file="/Users/guillot/Git/Partiels/BinaryData/Tests/Sound.wav" channel="1"/>
+  </reader>
+  <layout value="dc5e59b9f3654979946bb384fcf0e673"/>
+  <timeZoom MiscModelVersion="131084" globalRange_start="0.0" globalRange_end="1.0"
+            minimumLength="0.01160997732426304" visibleRange_start="0.0"
+            visibleRange_end="1.0">
+    <grid MiscModelVersion="131084" tickReference="0.0" mainTickInterval="0"
+          tickPowerBase="2.0" tickDivisionFactor="10.0"/>
+  </timeZoom>
+  <transport MiscModelVersion="131084" startPlayhead="0.4713055954088953"
+             looping="0" loopRange_start="0.0" loopRange_end="0.0" stopAtLoopEnd="0"
+             autoScroll="1" gain="3.981071705534973" magnetize="0"/>
+  <groups MiscModelVersion="131084" identifier="dc5e59b9f3654979946bb384fcf0e673"
+          name="Group 1" height="748" colour="0" expanded="0" referenceid="">
+    <layout value="e9d315cd57c74c45a617e33f7db701f1"/>
+    <zoom MiscModelVersion="131084" globalRange_start="0.0" globalRange_end="1.0"
+          minimumLength="0.0" visibleRange_start="0.0" visibleRange_end="1.0">
+      <grid MiscModelVersion="131084" tickReference="0.0" mainTickInterval="3"
+            tickPowerBase="2.0" tickDivisionFactor="5.0"/>
+    </zoom>
+  </groups>
+  <tracks MiscModelVersion="131084" identifier="e9d315cd57c74c45a617e33f7db701f1"
+          name="Markers" input="" sampleRate="44100.0" height="78" font="Nunito Sans; 14.0 Regular"
+          lineWidth="2.0" showInGroup="1" sendViaOsc="0" zoomValueMode="0"
+          zoomLogScale="0" zoomLink="1">
+    <file path="/Users/guillot/Git/Partiels/BinaryData/Tests/Markers.csv"
+          commit="">
+      <args>
+        <pair key="separator" value=","/>
+        <pair key="useendtime" value="true"/>
+      </args>
+    </file>
+    <description name="" inputDomain="0" maker="" version="0" category="" details="">
+      <defaultState blockSize="0" stepSize="0" windowType="3"/>
+      <output identifier="" name="" description="" unit="" hasFixedBinCount="0"
+              binCount="0" hasKnownExtents="0" minValue="0.0" maxValue="0.0"
+              isQuantized="0" quantizeStep="0.0" sampleType="0" sampleRate="0.0"
+              hasDuration="0"/>
+      <input identifier="" name="" description="" unit="" hasFixedBinCount="0"
+             binCount="0" hasKnownExtents="0" minValue="0.0" maxValue="0.0"
+             isQuantized="0" quantizeStep="0.0" sampleType="0" sampleRate="0.0"
+             hasDuration="0"/>
+    </description>
+    <key identifier="" feature=""/>
+    <state blockSize="0" stepSize="0" windowType="3"/>
+    <colours map="7" background="0" foreground="ff00f345" duration="667e7a7d"
+             text="ff000000" shadow="0"/>
+    <labelLayout position="12.0" justification="0"/>
+    <channelsLayout value="1"/>
+    <channelsLayout value="1"/>
+    <valueZoom MiscModelVersion="131084" globalRange_start="0.0" globalRange_end="0.0"
+               minimumLength="0.0" visibleRange_start="0.0" visibleRange_end="0.0">
+      <grid MiscModelVersion="131084" tickReference="0.0" mainTickInterval="3"
+            tickPowerBase="2.0" tickDivisionFactor="5.0"/>
+    </valueZoom>
+    <binZoom MiscModelVersion="131084" globalRange_start="0.0" globalRange_end="0.0"
+             minimumLength="0.0" visibleRange_start="0.0" visibleRange_end="0.0">
+      <grid MiscModelVersion="131084" tickReference="0.0" mainTickInterval="3"
+            tickPowerBase="2.0" tickDivisionFactor="5.0"/>
+    </binZoom>
+  </tracks>
+</document>

--- a/BinaryData/Tests/TemplateWithFileWindows.ptldoc
+++ b/BinaryData/Tests/TemplateWithFileWindows.ptldoc
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<document MiscModelVersion="131084" viewport_x="0" viewport_y="0" path="C:\Users\pierr\Documents\Gitlab\Partiels\BinaryData\Tests\TemplateWithFileWindows.ptldoc"
+          grid="1" autoresize="1" samplerate="44100.0" channels="2">
+  <reader>
+    <value file="C:\Users\pierr\Documents\Gitlab\Partiels\BinaryData\Tests\Sound.wav"
+           channel="0"/>
+  </reader>
+  <reader>
+    <value file="C:\Users\pierr\Documents\Gitlab\Partiels\BinaryData\Tests\Sound.wav"
+           channel="1"/>
+  </reader>
+  <layout value="dc5e59b9f3654979946bb384fcf0e673"/>
+  <timeZoom MiscModelVersion="131084" globalRange_start="0.0" globalRange_end="4.338231292517007"
+            minimumLength="0.01160997732426304" visibleRange_start="0.0"
+            visibleRange_end="1.0">
+    <grid MiscModelVersion="131084" tickReference="0.0" mainTickInterval="0"
+          tickPowerBase="2.0" tickDivisionFactor="10.0"/>
+  </timeZoom>
+  <transport MiscModelVersion="131084" startPlayhead="0.4713055954088953"
+             looping="0" loopRange_start="0.0" loopRange_end="0.0" stopAtLoopEnd="0"
+             autoScroll="1" gain="3.981071705534973" magnetize="0"/>
+  <groups MiscModelVersion="131084" identifier="dc5e59b9f3654979946bb384fcf0e673"
+          name="Group 1" height="734" colour="0" expanded="0" referenceid="">
+    <layout value="e9d315cd57c74c45a617e33f7db701f1"/>
+    <zoom MiscModelVersion="131084" globalRange_start="0.0" globalRange_end="1.0"
+          minimumLength="0.0" visibleRange_start="0.0" visibleRange_end="1.0">
+      <grid MiscModelVersion="131084" tickReference="0.0" mainTickInterval="3"
+            tickPowerBase="2.0" tickDivisionFactor="5.0"/>
+    </zoom>
+  </groups>
+  <tracks MiscModelVersion="131084" identifier="e9d315cd57c74c45a617e33f7db701f1"
+          name="Markers" input="" sampleRate="44100.0" height="78" font="Nunito Sans; 14.0 Regular"
+          lineWidth="2.0" showInGroup="1" sendViaOsc="0" zoomValueMode="0"
+          zoomLogScale="0" zoomLink="1">
+    <file path="C:\Users\pierr\Documents\Gitlab\Partiels\BinaryData\Tests\Markers.csv"
+          commit="">
+      <args>
+        <pair key="separator" value=","/>
+        <pair key="useendtime" value="true"/>
+      </args>
+    </file>
+    <description name="" inputDomain="0" maker="" version="0" category="" details="">
+      <defaultState blockSize="0" stepSize="0" windowType="3"/>
+      <output identifier="" name="" description="" unit="" hasFixedBinCount="0"
+              binCount="0" hasKnownExtents="0" minValue="0.0" maxValue="0.0"
+              isQuantized="0" quantizeStep="0.0" sampleType="0" sampleRate="0.0"
+              hasDuration="0"/>
+      <input identifier="" name="" description="" unit="" hasFixedBinCount="0"
+             binCount="0" hasKnownExtents="0" minValue="0.0" maxValue="0.0"
+             isQuantized="0" quantizeStep="0.0" sampleType="0" sampleRate="0.0"
+             hasDuration="0"/>
+    </description>
+    <key identifier="" feature=""/>
+    <state blockSize="0" stepSize="0" windowType="3"/>
+    <colours map="7" background="0" foreground="ff00f345" duration="667e7a7d"
+             text="ff000000" shadow="0"/>
+    <labelLayout position="12.0" justification="0"/>
+    <channelsLayout value="1"/>
+    <channelsLayout value="1"/>
+    <valueZoom MiscModelVersion="131084" globalRange_start="0.0" globalRange_end="0.0"
+               minimumLength="0.0" visibleRange_start="0.0" visibleRange_end="0.0">
+      <grid MiscModelVersion="131084" tickReference="0.0" mainTickInterval="3"
+            tickPowerBase="2.0" tickDivisionFactor="5.0"/>
+    </valueZoom>
+    <binZoom MiscModelVersion="131084" globalRange_start="0.0" globalRange_end="0.0"
+             minimumLength="0.0" visibleRange_start="0.0" visibleRange_end="0.0">
+      <grid MiscModelVersion="131084" tickReference="0.0" mainTickInterval="3"
+            tickPowerBase="2.0" tickDivisionFactor="5.0"/>
+    </binZoom>
+  </tracks>
+</document>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -403,6 +403,9 @@ set_tests_properties(ExportPng PROPERTIES ENVIRONMENT "VAMP_PATH=$<TARGET_FILE_D
 add_test(NAME ExportCsv COMMAND Partiels --export --input=${TESTS_DIRECTORY}/Sound.wav --template=${TESTS_DIRECTORY}/Template.ptldoc --output=${CMAKE_CURRENT_BINARY_DIR}/TestsOutput/CSV/ --format=csv --nogrids --header --separator=,)
 set_tests_properties(ExportCsv PROPERTIES ENVIRONMENT "VAMP_PATH=$<TARGET_FILE_DIR:vamp-example-plugins>")
 
+add_test(NAME ExportCsvWithFileUnix COMMAND Partiels --export --input=${TESTS_DIRECTORY}/Sound.wav --template=${TESTS_DIRECTORY}/TemplateWithFileUnix.ptldoc --output=${CMAKE_CURRENT_BINARY_DIR}/TestsOutput/CSV/ --format=csv --nogrids --header --separator=,)
+set_tests_properties(ExportCsvWithFileUnix PROPERTIES ENVIRONMENT "VAMP_PATH=$<TARGET_FILE_DIR:vamp-example-plugins>")
+
 add_test(NAME ExportJson COMMAND Partiels --export --input=${TESTS_DIRECTORY}/Sound.wav --template=${TESTS_DIRECTORY}/Template.ptldoc --output=${CMAKE_CURRENT_BINARY_DIR}/TestsOutput/JSON/ --format=json)
 set_tests_properties(ExportJson PROPERTIES ENVIRONMENT "VAMP_PATH=$<TARGET_FILE_DIR:vamp-example-plugins>")
 add_test(NAME ExportJsonCompareSpectrum COMMAND ${CMAKE_COMMAND} -E compare_files "${TESTS_DIRECTORY}/Expected/JSON/Sound Group 1_Simple Power Spectrum.json" "${CMAKE_CURRENT_BINARY_DIR}/TestsOutput/JSON/Sound Group 1_Simple Power Spectrum.json")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -406,6 +406,9 @@ set_tests_properties(ExportCsv PROPERTIES ENVIRONMENT "VAMP_PATH=$<TARGET_FILE_D
 add_test(NAME ExportCsvWithFileUnix COMMAND Partiels --export --input=${TESTS_DIRECTORY}/Sound.wav --template=${TESTS_DIRECTORY}/TemplateWithFileUnix.ptldoc --output=${CMAKE_CURRENT_BINARY_DIR}/TestsOutput/CSV/ --format=csv --nogrids --header --separator=,)
 set_tests_properties(ExportCsvWithFileUnix PROPERTIES ENVIRONMENT "VAMP_PATH=$<TARGET_FILE_DIR:vamp-example-plugins>")
 
+add_test(NAME ExportCsvWithFileWindows COMMAND Partiels --export --input=${TESTS_DIRECTORY}/Sound.wav --template=${TESTS_DIRECTORY}/TemplateWithFileWindows.ptldoc --output=${CMAKE_CURRENT_BINARY_DIR}/TestsOutput/CSV/ --format=csv --nogrids --header --separator=,)
+set_tests_properties(ExportCsvWithFileWindows PROPERTIES ENVIRONMENT "VAMP_PATH=$<TARGET_FILE_DIR:vamp-example-plugins>")
+
 add_test(NAME ExportCsvWithFileNoColour COMMAND Partiels --export --input=${TESTS_DIRECTORY}/Sound.wav --template=${TESTS_DIRECTORY}/TemplateWithFileNoColour.ptldoc --output=${CMAKE_CURRENT_BINARY_DIR}/TestsOutput/CSV/ --format=csv --nogrids --header --separator=,)
 set_tests_properties(ExportCsvWithFileNoColour PROPERTIES ENVIRONMENT "VAMP_PATH=$<TARGET_FILE_DIR:vamp-example-plugins>")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -406,6 +406,9 @@ set_tests_properties(ExportCsv PROPERTIES ENVIRONMENT "VAMP_PATH=$<TARGET_FILE_D
 add_test(NAME ExportCsvWithFileUnix COMMAND Partiels --export --input=${TESTS_DIRECTORY}/Sound.wav --template=${TESTS_DIRECTORY}/TemplateWithFileUnix.ptldoc --output=${CMAKE_CURRENT_BINARY_DIR}/TestsOutput/CSV/ --format=csv --nogrids --header --separator=,)
 set_tests_properties(ExportCsvWithFileUnix PROPERTIES ENVIRONMENT "VAMP_PATH=$<TARGET_FILE_DIR:vamp-example-plugins>")
 
+add_test(NAME ExportCsvWithFileNoColour COMMAND Partiels --export --input=${TESTS_DIRECTORY}/Sound.wav --template=${TESTS_DIRECTORY}/TemplateWithFileNoColour.ptldoc --output=${CMAKE_CURRENT_BINARY_DIR}/TestsOutput/CSV/ --format=csv --nogrids --header --separator=,)
+set_tests_properties(ExportCsvWithFileNoColour PROPERTIES ENVIRONMENT "VAMP_PATH=$<TARGET_FILE_DIR:vamp-example-plugins>")
+
 add_test(NAME ExportJson COMMAND Partiels --export --input=${TESTS_DIRECTORY}/Sound.wav --template=${TESTS_DIRECTORY}/Template.ptldoc --output=${CMAKE_CURRENT_BINARY_DIR}/TestsOutput/JSON/ --format=json)
 set_tests_properties(ExportJson PROPERTIES ENVIRONMENT "VAMP_PATH=$<TARGET_FILE_DIR:vamp-example-plugins>")
 add_test(NAME ExportJsonCompareSpectrum COMMAND ${CMAKE_COMMAND} -E compare_files "${TESTS_DIRECTORY}/Expected/JSON/Sound Group 1_Simple Power Spectrum.json" "${CMAKE_CURRENT_BINARY_DIR}/TestsOutput/JSON/Sound Group 1_Simple Power Spectrum.json")

--- a/Dependencies/Misc/Source/MiscXmlParser.cpp
+++ b/Dependencies/Misc/Source/MiscXmlParser.cpp
@@ -136,6 +136,29 @@ auto XmlParser::fromXml<juce::StringPairArray>(juce::XmlElement const& xml, juce
     return value;
 }
 
+void XmlParser::replaceAllAttributeValues(juce::XmlElement& element, juce::String const& previousValue, juce::String const& newValue)
+{
+    if(previousValue.isEmpty())
+    {
+        return;
+    }
+    for(auto i = 0; i < element.getNumAttributes(); ++i)
+    {
+        auto const& currentValue = element.getAttributeValue(i);
+        if(currentValue.contains(previousValue))
+        {
+            element.setAttribute(element.getAttributeName(i), currentValue.replace(previousValue, newValue));
+        }
+    }
+    for(auto* child : element.getChildIterator())
+    {
+        if(child != nullptr)
+        {
+            replaceAllAttributeValues(*child, previousValue, newValue);
+        }
+    }
+}
+
 class XmlParserUnitTest
 : public juce::UnitTest
 {

--- a/Dependencies/Misc/Source/MiscXmlParser.h
+++ b/Dependencies/Misc/Source/MiscXmlParser.h
@@ -297,6 +297,9 @@ namespace XmlParser
     template <>
     auto fromXml<juce::StringPairArray>(juce::XmlElement const& xml, juce::Identifier const& attributeName, juce::StringPairArray const& defaultValue)
         -> juce::StringPairArray;
+
+    //! @brief Replaces all occurrences of a specific attribute value in the XML element with a new value.
+    void replaceAllAttributeValues(juce::XmlElement& element, juce::String const& previousValue, juce::String const& newValue);
 } // namespace XmlParser
 
 MISC_FILE_END

--- a/Source/Document/AnlDocumentExecutor.cpp
+++ b/Source/Document/AnlDocumentExecutor.cpp
@@ -33,9 +33,13 @@ juce::Result Document::Executor::load(juce::File const& audioFile, juce::File co
     auto fileResult = Document::FileBased::parse(templateFile);
     if(fileResult.index() == 1_z)
     {
-        return juce::Result::fail(std::get_if<1>(&fileResult)->getErrorMessage());
+        return std::get<1>(fileResult);
     }
-    auto xml = std::move(*std::get_if<0>(&fileResult));
+    auto xml = std::move(std::get<0>(fileResult));
+
+    // Adjust the path in the XML to match the new template file location
+    XmlParser::replaceAllAttributeValues(*xml.get(), FileBased::getPathReplacement(*xml.get()), templateFile.getParentDirectory().getFullPathName() + juce::File::getSeparatorString());
+
     Document::FileBased::loadTemplate(mAccessor, *xml.get(), adaptOnSampleRate);
 
     anlDebug("Executor", "Sanitize document...");

--- a/Source/Document/AnlDocumentFileBased.h
+++ b/Source/Document/AnlDocumentFileBased.h
@@ -28,6 +28,11 @@ namespace Document
         static void loadTemplate(Accessor& accessor, juce::XmlElement const& xml, bool adaptOnSampleRate);
         static juce::File getConsolidateDirectory(juce::File const& file);
 
+        //! @brief Returns the original path to replace that corresponds to the parent directory of the 'path' attribute.
+        //! @details The path could be formatted for another operating system (Unix/Windows) and the format should
+        //! be preserved to ensure that the other paths will be correctly replaced.
+        static juce::String getPathReplacement(juce::XmlElement const& element);
+
     protected:
         // juce::FileBasedDocument
         juce::String getDocumentTitle() override;
@@ -40,8 +45,6 @@ namespace Document
     private:
         // juce::AsyncUpdater
         void handleAsyncUpdate() override;
-
-        static void replacePath(juce::XmlElement& element, juce::String const& oldPath, juce::String const& newPath);
 
         Director& mDirector;
         Accessor& mAccessor;


### PR DESCRIPTION
When using a template, the paths to the result files are not updated according to the location of the template file on the system. If a template uses a result file whose location is relative to that of the template, this file cannot be located if the location of the template file is changed. 

When sharing documents between Unix and Windows systems, the saved file paths are not well interpreted, so the relative files are not found.   

This PR corrects these issues, cleans up  and clarifies the functions.
The PR also adds two tests related to this PR https://github.com/Ircam-Partiels/Partiels/pull/156.

