### PR TITLE
Fix the default value handling for containers stored in XML format

### DIFF
--- a/Dependencies/Misc/Source/MiscXmlParser.cpp
+++ b/Dependencies/Misc/Source/MiscXmlParser.cpp
@@ -159,6 +159,21 @@ void XmlParser::replaceAllAttributeValues(juce::XmlElement& element, juce::Strin
     }
 }
 
+void XmlParser::migrateContainerFormat(juce::XmlElement& parent, juce::String const& name)
+{
+    auto const* firstChild = parent.getChildByName(name);
+    if(firstChild != nullptr && (firstChild->hasAttribute("value") || firstChild->getChildByName("value") != nullptr))
+    {
+        auto newElement = std::make_unique<juce::XmlElement>(name);
+        while(auto* child = parent.getChildByName(name))
+        {
+            parent.removeChildElement(child, false);
+            newElement->addChildElement(child);
+        }
+        parent.addChildElement(newElement.release());
+    }
+}
+
 class XmlParserUnitTest
 : public juce::UnitTest
 {

--- a/Source/Application/AnlApplicationModel.cpp
+++ b/Source/Application/AnlApplicationModel.cpp
@@ -15,10 +15,6 @@ juce::File Application::Accessor::getFactoryTemplateFile()
 std::unique_ptr<juce::XmlElement> Application::Accessor::parseXml(juce::XmlElement const& xml, int version)
 {
     auto copy = std::make_unique<juce::XmlElement>(xml);
-    if(copy == nullptr)
-    {
-        return nullptr;
-    }
     if(version < 0x10300)
     {
         if(auto* child = copy->getChildByName("defaultTemplateFile"))
@@ -26,6 +22,12 @@ std::unique_ptr<juce::XmlElement> Application::Accessor::parseXml(juce::XmlEleme
             copy->removeChildElement(child, true);
         }
         XmlParser::toXml(*copy.get(), "defaultTemplateFile", juce::File{});
+    }
+    if(version < 0x20301)
+    {
+        // Migrate old container format (multiple sibling elements) to new format (parent with children)
+        XmlParser::migrateContainerFormat(*copy.get(), "recentlyOpenedFilesList");
+        XmlParser::migrateContainerFormat(*copy.get(), "routingMatrix");
     }
     return copy;
 }

--- a/Source/Document/AnlDocumentModel.h
+++ b/Source/Document/AnlDocumentModel.h
@@ -131,13 +131,19 @@ namespace Document
         std::unique_ptr<juce::XmlElement> parseXml(juce::XmlElement const& xml, int version) override
         {
             auto copy = std::make_unique<juce::XmlElement>(xml);
-            if(copy != nullptr && version <= 0x7)
+            if(version <= 0x7)
             {
                 if(copy->hasAttribute("file"))
                 {
                     auto const file = XmlParser::fromXml(*copy.get(), "file", juce::File{});
                     XmlParser::toXml(*copy.get(), "reader", std::vector<AudioFileLayout>{{file}});
                 }
+            }
+            if(version < 0x20301)
+            {
+                // Migrate old container format (multiple sibling elements) to new format (parent with children)
+                XmlParser::migrateContainerFormat(*copy.get(), "reader");
+                XmlParser::migrateContainerFormat(*copy.get(), "layout");
             }
             return copy;
         }

--- a/Source/Group/AnlGroupModel.cpp
+++ b/Source/Group/AnlGroupModel.cpp
@@ -5,17 +5,19 @@ ANALYSE_FILE_BEGIN
 std::unique_ptr<juce::XmlElement> Group::Accessor::parseXml(juce::XmlElement const& xml, int version)
 {
     auto copy = std::make_unique<juce::XmlElement>(xml);
-    if(copy != nullptr)
+    if(version <= 0x20001)
     {
-        if(version <= 0x20001)
+        if(copy->hasAttribute("zoomid"))
         {
-            if(copy->hasAttribute("zoomid"))
-            {
-                auto const identifier = XmlParser::fromXml(*copy.get(), "zoomid", juce::String{});
-                copy->removeAttribute("zoomid");
-                XmlParser::toXml(*copy.get(), "referenceid", identifier);
-            }
+            auto const identifier = XmlParser::fromXml(*copy.get(), "zoomid", juce::String{});
+            copy->removeAttribute("zoomid");
+            XmlParser::toXml(*copy.get(), "referenceid", identifier);
         }
+    }
+    if(version < 0x20301)
+    {
+        // Migrate old container format (multiple sibling elements) to new format (parent with children)
+        XmlParser::migrateContainerFormat(*copy.get(), "layout");
     }
     return copy;
 }

--- a/Source/Plugin/AnlPluginListModel.cpp
+++ b/Source/Plugin/AnlPluginListModel.cpp
@@ -16,10 +16,16 @@ PluginList::Accessor::Accessor()
 std::unique_ptr<juce::XmlElement> PluginList::Accessor::parseXml(juce::XmlElement const& xml, int version)
 {
     auto copy = std::make_unique<juce::XmlElement>(xml);
-    if(copy != nullptr && version <= 0x8)
+    if(version <= 0x8)
     {
         XmlParser::toXml(*copy.get(), "useEnvVariable", true);
         XmlParser::toXml(*copy.get(), "searchPath", getDefaultSearchPath());
+    }
+    if(version < 0x20301)
+    {
+        // Migrate old container format (multiple sibling elements) to new format (parent with children)
+        XmlParser::migrateContainerFormat(*copy.get(), "searchPath");
+        XmlParser::migrateContainerFormat(*copy.get(), "webReferences");
     }
     return copy;
 }

--- a/Source/Track/AnlTrackModel.h
+++ b/Source/Track/AnlTrackModel.h
@@ -393,6 +393,8 @@ namespace Track
             {
             }
             // clang-format on
+
+            std::unique_ptr<juce::XmlElement> parseXml(juce::XmlElement const& xml, int version) override;
         };
     } // namespace PresetList
 } // namespace Track


### PR DESCRIPTION
The default values for containers (`std::vector`, `std::set`, `std::map`) were not supported because the way the data was saved made it impossible to determine whether the containers were empty or whether the value was undefined.

The problem is solved by using an additional element hierarchy that contains a sub-element for each value. If this parent element is not defined, the default value must be used.

This correction also includes cleaning up code related to unnecessary verification of `std::make_unique<>`. 

Backward compatibility still needs to be ensured via the `parseXml()` methods of the `Accessor` classes. If the `Accessor` contains a container attribute (such as `Application::AttrType::recentlyOpenedFilesList`), the old container XML representation must be replaced with the new XML representation, for instance:
```cpp
if(version < 0x20300)
{
    auto const* firstChild = copy->getChildByName("recentlyOpenedFilesList");
    if(firstChild != nullptr && firstChild->hasAttribute("value"))
    {
        auto newElement = std::make_unique<juce::XmlElement>("recentlyOpenedFilesList");
        while(firstChild != nullptr)
        {
            newElement->addChildElement(std::make_unique<juce::XmlElement>(*firstChild).release());
            firstChild = firstChild->getNextElementWithTagName("recentlyOpenedFilesList");
        }
        copy->deleteAllChildElementsWithTagName("recentlyOpenedFilesList");
        copy->addChildElement(newElement.release());
    }
}
```