### PR TITLE
Improve support for plugin parameters

### DIFF
--- a/Source/Group/AnlGroupPropertyProcessorsSection.cpp
+++ b/Source/Group/AnlGroupPropertyProcessorsSection.cpp
@@ -94,11 +94,7 @@ void Group::PropertyProcessorsSection::resized()
     setBounds(mPropertyStepSize);
     for(auto& property : mParameterProperties)
     {
-        MiscWeakAssert(property.second != nullptr);
-        if(property.second != nullptr)
-        {
-            setBounds(*property.second.get());
-        }
+        setBounds(*property.second.get());
     }
     setSize(getWidth(), bounds.getY());
 }
@@ -573,13 +569,9 @@ void Group::PropertyProcessorsSection::updateParameters()
             if(mParameterProperties.count(parameter.identifier) == 0_z)
             {
                 auto property = Plugin::Tools::createProperty(parameter, changeValue);
-                MiscWeakAssert(property != nullptr);
-                if(property != nullptr)
-                {
-                    addAndMakeVisible(property.get());
-                    property->setEnabled(hasPlugin);
-                    mParameterProperties[parameter.identifier] = std::move(property);
-                }
+                addAndMakeVisible(property.get());
+                property->setEnabled(hasPlugin);
+                mParameterProperties[parameter.identifier] = std::move(property);
             }
         }
     }
@@ -616,59 +608,27 @@ void Group::PropertyProcessorsSection::updateState()
                 values.insert(it->second);
             }
         }
-        if(auto* propertyList = dynamic_cast<PropertyList*>(parameter.second.get()))
+
+        auto propertyIt = mParameterProperties.find(parameter.first);
+        auto const parameterIt = [&]()
         {
-            if(values.empty())
+            for(auto const& trackAcsr : trackAcsrs)
             {
-                propertyList->setEnabled(!values.empty());
-                propertyList->entry.setText(juce::translate("No Value"), juce::NotificationType::dontSendNotification);
+                auto const& description = trackAcsr.get().getAttr<Track::AttrType::description>();
+                auto const it = std::find_if(description.parameters.cbegin(), description.parameters.cend(), [&](auto const& p)
+                                             {
+                                                 return p.identifier == parameter.first;
+                                             });
+                if(it != description.parameters.cend())
+                {
+                    return std::make_optional(it);
+                }
             }
-            else if(values.size() == 1_z)
-            {
-                propertyList->entry.setSelectedItemIndex(static_cast<int>(std::floor(*values.cbegin())), juce::NotificationType::dontSendNotification);
-            }
-            else
-            {
-                propertyList->entry.setText(juce::translate("Multiple Values"), juce::NotificationType::dontSendNotification);
-            }
-        }
-        else if(auto* propertyNumber = dynamic_cast<PropertyNumber*>(parameter.second.get()))
+            return std::optional<std::vector<Plugin::Parameter>::const_iterator>{};
+        }();
+        if(propertyIt != mParameterProperties.end() && parameterIt.has_value())
         {
-            if(values.empty())
-            {
-                propertyNumber->setEnabled(!values.empty());
-                propertyNumber->entry.setText(juce::translate("No Value"), juce::NotificationType::dontSendNotification);
-            }
-            if(values.size() == 1_z)
-            {
-                propertyNumber->entry.setValue(static_cast<double>(*values.cbegin()), juce::NotificationType::dontSendNotification);
-            }
-            else
-            {
-                propertyNumber->entry.setText(juce::translate("Multiple Values"), juce::NotificationType::dontSendNotification);
-            }
-        }
-        else if(auto* propertyToggle = dynamic_cast<PropertyToggle*>(parameter.second.get()))
-        {
-            if(values.empty())
-            {
-                propertyToggle->entry.getProperties().remove("Multiple Values");
-                propertyToggle->setEnabled(!values.empty());
-            }
-            else if(values.size() == 1_z)
-            {
-                propertyToggle->entry.getProperties().remove("Multiple Values");
-                propertyToggle->entry.setToggleState(*values.cbegin() > 0.5f, juce::NotificationType::dontSendNotification);
-            }
-            else
-            {
-                propertyToggle->entry.getProperties().set("Multiple Values", {true});
-                propertyToggle->entry.setToggleState(false, juce::NotificationType::dontSendNotification);
-            }
-        }
-        else
-        {
-            MiscWeakAssert(false && "property unsupported");
+            Plugin::Tools::setPropertyValue(*propertyIt->second.get(), *parameterIt.value(), values, juce::NotificationType::dontSendNotification);
         }
     }
 }

--- a/Source/Plugin/AnlPluginTools.cpp
+++ b/Source/Plugin/AnlPluginTools.cpp
@@ -22,13 +22,15 @@ std::unique_ptr<juce::Component> Plugin::Tools::createProperty(Parameter const& 
     auto const name = juce::String(Format::withFirstCharUpperCase(parameter.name));
     if(!parameter.valueNames.empty())
     {
+        auto const minValue = parameter.minValue;
+        auto const quantizeStep = parameter.isQuantized && std::abs(parameter.quantizeStep) > std::numeric_limits<float>::epsilon() ? parameter.quantizeStep : 1.0f;
         return std::make_unique<PropertyList>(name, parameter.description, parameter.unit, parameter.valueNames, [=](size_t index)
                                               {
                                                   if(applyChange == nullptr)
                                                   {
                                                       return;
                                                   }
-                                                  applyChange(parameter, static_cast<float>(index));
+                                                  applyChange(parameter, static_cast<float>(index) * quantizeStep + minValue);
                                               });
     }
     else if(parameter.isQuantized && std::abs(parameter.quantizeStep - 1.0f) < std::numeric_limits<float>::epsilon() && std::abs(parameter.minValue) < std::numeric_limits<float>::epsilon() && std::abs(parameter.maxValue - 1.0f) < std::numeric_limits<float>::epsilon())
@@ -52,6 +54,64 @@ std::unique_ptr<juce::Component> Plugin::Tools::createProperty(Parameter const& 
                                                 }
                                                 applyChange(parameter, static_cast<float>(value));
                                             });
+}
+
+void Plugin::Tools::setPropertyValue(juce::Component& property, Parameter const& parameter, std::set<float> const& values, juce::NotificationType notification)
+{
+
+    if(auto* propertyList = dynamic_cast<PropertyList*>(&property))
+    {
+        if(values.empty())
+        {
+            propertyList->entry.setText(juce::translate("No Value"), notification);
+        }
+        else if(values.size() == 1_z)
+        {
+            auto const minValue = parameter.minValue;
+            auto const quantizeStep = parameter.isQuantized && std::abs(parameter.quantizeStep) > std::numeric_limits<float>::epsilon() ? parameter.quantizeStep : 1.0f;
+            propertyList->entry.setSelectedItemIndex(static_cast<int>(std::round((*values.cbegin() - minValue) / quantizeStep)), notification);
+        }
+        else
+        {
+            propertyList->entry.setText(juce::translate("Multiple Values"), notification);
+        }
+    }
+    else if(auto* propertyNumber = dynamic_cast<PropertyNumber*>(&property))
+    {
+        if(values.empty())
+        {
+            propertyNumber->entry.setText(juce::translate("No Value"), notification);
+        }
+        else if(values.size() == 1_z)
+        {
+            propertyNumber->entry.setValue(static_cast<double>(*values.cbegin()), notification);
+        }
+        else
+        {
+            propertyNumber->entry.setText(juce::translate("Multiple Values"), notification);
+        }
+    }
+    else if(auto* propertyToggle = dynamic_cast<PropertyToggle*>(&property))
+    {
+        if(values.empty())
+        {
+            propertyToggle->entry.getProperties().remove("Multiple Values");
+        }
+        else if(values.size() == 1_z)
+        {
+            propertyToggle->entry.getProperties().remove("Multiple Values");
+            propertyToggle->entry.setToggleState(*values.cbegin() > 0.5f, notification);
+        }
+        else
+        {
+            propertyToggle->entry.getProperties().set("Multiple Values", {true});
+            propertyToggle->entry.setToggleState(false, notification);
+        }
+    }
+    else
+    {
+        MiscWeakAssert(false && "property unsupported");
+    }
 }
 
 std::unique_ptr<Ive::PluginWrapper> Plugin::Tools::createPluginWrapper(Key const& key, double readerSampleRate)

--- a/Source/Plugin/AnlPluginTools.h
+++ b/Source/Plugin/AnlPluginTools.h
@@ -24,6 +24,8 @@ namespace Plugin
     {
         juce::String rangeToString(float min, float max, bool quantized, float step);
         std::unique_ptr<juce::Component> createProperty(Parameter const& parameter, std::function<void(Parameter const& parameter, float value)> applyChange);
+        void setPropertyValue(juce::Component& property, Parameter const& parameter, std::set<float> const& values, juce::NotificationType notification);
+
         std::unique_ptr<Ive::PluginWrapper> createPluginWrapper(Key const& key, double readerSampleRate);
         std::vector<std::unique_ptr<Ive::PluginWrapper>> createPluginWrappers(Key const& key, State const& state, size_t numReaderChannels, double readerSampleRate);
         std::optional<size_t> getFeatureIndex(Vamp::Plugin const& plugin, std::string const& feature);

--- a/Source/Track/AnlTrackDirector.cpp
+++ b/Source/Track/AnlTrackDirector.cpp
@@ -126,11 +126,20 @@ Track::Director::Director(Accessor& accessor, juce::UndoManager& undoManager, Hi
             {
                 auto const& description = mAccessor.getAttr<AttrType::description>();
                 auto state = mAccessor.getAttr<AttrType::state>();
+                // Update the default values of the parameters if they are not already set
+                // to avoid overwriting user values when changing the plugin key for example
+                for(auto const& parameter : description.parameters)
+                {
+                    if(!state.parameters.count(parameter.identifier))
+                    {
+                        state.parameters[parameter.identifier] = parameter.defaultValue;
+                    }
+                }
                 if(description.inputDomain == Plugin::InputDomain::TimeDomain && description.defaultState.blockSize != 0_z && state.blockSize != description.defaultState.blockSize)
                 {
                     state.blockSize = description.defaultState.blockSize;
-                    mAccessor.setAttr<AttrType::state>(state, notification);
                 }
+                mAccessor.setAttr<AttrType::state>(state, notification);
                 sanitizeZooms(notification);
                 sanitizeExtraOutputs(notification);
             }

--- a/Source/Track/AnlTrackPropertyProcessorSection.cpp
+++ b/Source/Track/AnlTrackPropertyProcessorSection.cpp
@@ -171,13 +171,9 @@ Track::PropertyProcessorSection::PropertyProcessorSection(Director& director, Pr
                 for(auto const& parameter : description.parameters)
                 {
                     auto property = Plugin::Tools::createProperty(parameter, applyValue);
-                    MiscWeakAssert(property != nullptr);
-                    if(property != nullptr)
-                    {
-                        addAndMakeVisible(property.get());
-                        property->setEnabled(hasPlugin);
-                        mParameterProperties[parameter.identifier] = std::move(property);
-                    }
+                    addAndMakeVisible(property.get());
+                    property->setEnabled(hasPlugin);
+                    mParameterProperties[parameter.identifier] = std::move(property);
                 }
 
                 auto const& programs = acsr.getAttr<AttrType::description>().programs;
@@ -282,11 +278,7 @@ void Track::PropertyProcessorSection::resized()
     setBounds(mPropertyInputTrack);
     for(auto& property : mParameterProperties)
     {
-        MiscWeakAssert(property.second != nullptr);
-        if(property.second != nullptr)
-        {
-            setBounds(*property.second.get());
-        }
+        setBounds(*property.second.get());
     }
     setBounds(mPropertyPreset);
     setBounds(mProgressBarAnalysis);
@@ -656,25 +648,14 @@ void Track::PropertyProcessorSection::updateState()
 
     for(auto const& parameter : state.parameters)
     {
-        auto it = mParameterProperties.find(parameter.first);
-        if(it != mParameterProperties.end() && it->second != nullptr)
+        auto propertyIt = mParameterProperties.find(parameter.first);
+        auto const parameterIt = std::find_if(description.parameters.cbegin(), description.parameters.cend(), [&](auto const& p)
+                                              {
+                                                  return p.identifier == parameter.first;
+                                              });
+        if(propertyIt != mParameterProperties.end() && parameterIt != description.parameters.cend())
         {
-            if(auto* propertyList = dynamic_cast<PropertyList*>(it->second.get()))
-            {
-                propertyList->entry.setSelectedItemIndex(static_cast<int>(std::floor(parameter.second)), silent);
-            }
-            else if(auto* propertyNumber = dynamic_cast<PropertyNumber*>(it->second.get()))
-            {
-                propertyNumber->entry.setValue(static_cast<double>(parameter.second), silent);
-            }
-            else if(auto* propertyToggle = dynamic_cast<PropertyToggle*>(it->second.get()))
-            {
-                propertyToggle->entry.setToggleState(parameter.second > 0.5f, silent);
-            }
-            else
-            {
-                MiscWeakAssert(false && "property unsupported");
-            }
+            Plugin::Tools::setPropertyValue(*propertyIt->second.get(), *parameterIt, {parameter.second}, silent);
         }
     }
 


### PR DESCRIPTION
The forward transform in `createProperty` maps a list selection index to a parameter value via `index * quantizeStep + minValue`, but the state→UI code in both the Track and Group property sections was inverting this incorrectly — treating the stored float value as a raw index. This causes wrong or out-of-range list selections for plugins whose list parameters have `minValue != 0` or `quantizeStep != 1`.

## Changes

- **`AnlTrackPropertyProcessorSection.cpp`**: When refreshing a `PropertyList` from state, look up the parameter descriptor from `description.parameters` and compute the correct index:
  ```cpp
  auto const index = static_cast<int>(std::round((value - paramDesc.minValue) / paramDesc.quantizeStep));
  propertyList->entry.setSelectedItemIndex(std::clamp(index, 0, numItems - 1), silent);
  ```
  Falls back to `floor(value)` if the descriptor is not found or `quantizeStep <= 0`.

- **`AnlGroupPropertyProcessorsSection.cpp`**: Same inverse transform, with the parameter descriptor looked up by searching `trackAcsrs` for the first track whose description contains the matching parameter identifier.